### PR TITLE
màj composer dependency fix guzzle bug on newer version of php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 		"php": ">=5.3.2",
 		"composer/installers": "v1.0.6",
 		"league/csv": "7.0.*@dev",
-		"guzzlehttp/guzzle": "~5.0"
+		"guzzlehttp/guzzle": "^5.3.3"
 	},
 	"autoload": {
 		"psr-4" : {


### PR DESCRIPTION
PHP Fatal error:  Cannot use lexical variable $eventName as a parameter name in 
```/simple-locator/vendor/guzzlehttp/guzzle/src/Event/Emitter.php on line 48```
related to 
https://github.com/googleapis/google-api-php-client/issues/1068